### PR TITLE
Added a lock file for changing more than one instance

### DIFF
--- a/lua/jumble/utils.lua
+++ b/lua/jumble/utils.lua
@@ -270,6 +270,28 @@ function M.get_theme(opts)
 	end
 end
 
+function M.try_lock()
+	local temp = colordirectory .. "temp"
+	local file = io.open(temp, "r")
+
+	if file then
+		file:close()
+		return false
+	end
+
+	-- Open
+	file = io.open(temp, "w")
+	if not file then
+		return false
+	end
+
+	local pid = vim.fn.getpid()
+	file:write(pid)
+	file:close()
+
+	return true
+end
+
 ---Update the colorscheme automatically by using a callback after the amount of time has passed
 ---@param opts opts
 function M.update_colorscheme(opts)

--- a/lua/jumble/utils.lua
+++ b/lua/jumble/utils.lua
@@ -423,7 +423,6 @@ function M.update_colorscheme()
 	local limit = 24 * 60 * 60 * 1000
 
 	-- Only do it if it's a day
-	-- TODO: Should we check if the lock file has not been deleted?
 	if timeleft > 0 and timeleft < limit then
 		M.deferred = vim.defer_fn(function()
 			M.auto_roll_theme(vim.g.colors_name)


### PR DESCRIPTION
Added a lockfile that allows only one instance of neovim to update the colorscheme and have all other instances read the file after it's been updated.